### PR TITLE
Add docker to lalsuite development image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,15 @@ LABEL name="LALSuite Development Debian Jessie" \
 
 # FIXME: this should use the lscsoft-lalsuite-dev meta-package but
 # that is out of date on Debian and needs to be updated
-RUN apt-get --assume-yes install autoconf \
+RUN apt-get update && apt-get --assume-yes install autoconf \
+      apt-transport-https \
       automake \
       bc \
+      ca-certificates \
+      curl \
       doxygen \
+      gettext \
+      gnupg2 \
       help2man \
       ldas-tools-framecpp-c-dev \
       libcfitsio-dev \
@@ -34,5 +39,18 @@ RUN apt-get --assume-yes install autoconf \
       python-scipy \
       python-shapely \
       python-six \
+      software-properties-common \
       swig3.0 \
-      texlive
+      texlive && \
+      rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/debian \
+      $(lsb_release -cs) \
+      stable"
+
+ENV DOCKER_VERSION ""
+RUN apt-get update && \
+    apt-get -y install docker-ce=$(apt-cache show docker-ce | grep 'Version:' | awk '{print $NF}' | grep "$DOCKER_VERSION" | head -n 1) && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I'd be happy for you to pull this into a new branch.  Would you also consider removing the 2nd "ligo" in the image names?